### PR TITLE
Refactor ethereum etl to improve performance

### DIFF
--- a/scripts/transform/schemas.py
+++ b/scripts/transform/schemas.py
@@ -36,7 +36,7 @@ eth_input_schema = StructType(
 
 transaction_output_schema = StructType(
     [
-        StructField("block_timestamp", StringType(), True),
+        StructField("block_timestamp", TimestampType(), True),
         StructField("block_number", LongType(), True),
         StructField("transaction_hash", StringType(), True),
         StructField("transaction_index", LongType(), True),


### PR DESCRIPTION
# Overview
Improved performance by:
- reducing transformation time by 33% (30s -> 20s)
- educing output size by 50% (~1000MB -> ~500MB)

# What Changed
Save block_timestamp as timestamp not string
Changed parquet compression method from snappy to zstd
Remove output schema (I suggest adding it in pipeline tests)
Adjust configuration of spark session
Chain tranformations 
Perform union once instead of in loop
Print transform time

# Exemplary record from output parquet
![image](https://github.com/user-attachments/assets/aca66bb5-d9f1-4d51-ab74-aa8027707cd2)
